### PR TITLE
ENH: catch SSL error as well

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 5.0.4
     hooks:
     -   id: flake8
 -   repo: https://github.com/psf/black
@@ -15,6 +15,6 @@ repos:
     -   id: black
         args: [--line-length=120]
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.9.1
+    rev: 5.10.1
     hooks:
     -   id: isort

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt") as fp:
 
 setup(
     name="twinfield",
-    version="2.0.5",
+    version="2.1.0-rc.1",
     author="Zypp",
     author_email="hello@zypp.io",
     description="Read and insert data using the Twinfield API.",

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ with open("requirements.txt") as fp:
 setup(
     name="twinfield",
     version="2.0.5",
-    author="Melvin Folkers, Erfan Nariman",
-    author_email="melvin@zypp.io, erfan@zypp.io",
+    author="Zypp",
+    author_email="hello@zypp.io",
     description="Read and insert data using the Twinfield API.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/twinfield/__init__.py
+++ b/twinfield/__init__.py
@@ -4,4 +4,4 @@
 from . import exceptions
 from .api import TwinfieldApi
 
-__version__ = "2.0.5"
+__version__ = "2.1.0-rc.1"

--- a/twinfield/core.py
+++ b/twinfield/core.py
@@ -21,11 +21,7 @@ class Base(TwinfieldLogin):
 
         self.namespaces_txt = {k: "{" + v + "}" for k, v in self.namespaces.items()}
         self.access_token = self.refresh_access_token()
-        self.header_req = {
-            "Content-Type": "text/xml",
-            "Accept-Charset": "utf-8",
-            "SOAPAction": "http://www.twinfield.com/ProcessXmlDocument",
-        }
+        self.header_req = {"Content-Type": "text/xml", "Accept-Charset": "utf-8"}
 
     def send_request(self, browse) -> requests.Response:
         """

--- a/twinfield/core.py
+++ b/twinfield/core.py
@@ -21,7 +21,12 @@ class Base(TwinfieldLogin):
 
         self.namespaces_txt = {k: "{" + v + "}" for k, v in self.namespaces.items()}
         self.access_token = self.refresh_access_token()
-        self.header_req = {"Content-Type": "text/xml", "Accept-Charset": "utf-8"}
+        self.header_req = {
+            "Content-Type": "text/xml",
+            "Accept-Charset": "utf-8",
+            "Accept-Encoding": "gzip, deflate",
+            "Connection": "Keep-Alive",
+        }
 
     def send_request(self, browse) -> requests.Response:
         """

--- a/twinfield/core.py
+++ b/twinfield/core.py
@@ -24,8 +24,7 @@ class Base(TwinfieldLogin):
         self.header_req = {
             "Content-Type": "text/xml",
             "Accept-Charset": "utf-8",
-            "Accept-Encoding": "gzip, deflate",
-            "Connection": "Keep-Alive",
+            "SOAPAction": "http://www.twinfield.com/ProcessXmlDocument",
         }
 
     def send_request(self, browse) -> requests.Response:

--- a/twinfield/login.py
+++ b/twinfield/login.py
@@ -5,6 +5,7 @@ import os
 import time
 
 import requests
+from requests.exceptions import SSLError
 
 from twinfield.exceptions import EnvironmentVariablesError
 
@@ -99,10 +100,13 @@ class TwinfieldLogin:
                         output = response
                 success = True
 
-            except ConnectionError:
+            except (ConnectionError, SSLError) as e:
+                logging.info(
+                    f"No response or error, retrying in {self.sec_wait} seconds. "
+                    f"Retry number: {retry}. Error message: {e}"
+                )
+                time.sleep(self.sec_wait)
                 # failed request, retry with new login.
                 self.cluster = self.determine_cluster()
-                logging.info(f"No response, retrying in {self.sec_wait} seconds. Retry number: {retry}")
-                time.sleep(self.sec_wait)
                 retry += 1
         return output

--- a/twinfield/login.py
+++ b/twinfield/login.py
@@ -101,7 +101,7 @@ class TwinfieldLogin:
                 success = True
 
             except (ConnectionError, SSLError) as e:
-                logging.info(
+                logging.exception(
                     f"No response or error, retrying in {self.sec_wait} seconds. "
                     f"Retry number: {retry}. Error message: {e}"
                 )


### PR DESCRIPTION
Lately we are also getting `SSLError`. Now we only catch `ConnectionError`. This PR will also catch the `SSLError` and retry based on that.

Also added new header based on [this](https://api.accounting2.twinfield.com/webservices/processxml.asmx?op=ProcessXmlDocument) example.