### PR TITLE
add head.office if not present in dataset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt") as fp:
 
 setup(
     name="twinfield",
-    version="2.1.0-rc.3",
+    version="2.1.0-rc.4",
     author="Melvin Folkers, Erfan Nariman",
     author_email="melvin@zypp.io, erfan@zypp.io",
     description="Read and insert data using the Twinfield API.",

--- a/twinfield/__init__.py
+++ b/twinfield/__init__.py
@@ -4,4 +4,4 @@
 from . import exceptions
 from .api import TwinfieldApi
 
-version = "2.1.0-rc.3"
+version = "2.1.0-rc.4"

--- a/twinfield/api.py
+++ b/twinfield/api.py
@@ -235,6 +235,9 @@ class TwinfieldApi(Base):
                 filters = {**filters, **period_filters}
 
                 df = self.browse(code=code, fields=fields, filters=filters, company=office, metadata=metadata)
+                if "head.office" not in df.columns:
+                    df["head.office"] = office
+
                 df_list.append(df)
 
         df = pd.concat(df_list)
@@ -265,6 +268,8 @@ class TwinfieldApi(Base):
             pbar.set_description(f"importing module {code} - {office}...")
 
             df = self.browse(code=code, fields=fields, filters=filters, company=office, metadata=metadata)
+            if "head.office" not in df.columns:
+                df["head.office"] = office
             df_list.append(df)
 
         df = pd.concat(df_list)

--- a/twinfield/api.py
+++ b/twinfield/api.py
@@ -243,35 +243,3 @@ class TwinfieldApi(Base):
         df = pd.concat(df_list)
 
         return df
-
-    def query_by_year_fast(self, code: str, year: int, filters: dict, fields: list = None):
-        """
-        Fastest way of querying browse code data. user is required to use filters, without it the results are to large
-        to be returned by the twinfield server.
-        """
-
-        metadata = self.metadata(code)
-
-        if not filters:
-            filters = {}
-
-        if not fields:
-            fields = metadata.index.tolist()
-
-        year_filter = {"fin.trs.head.yearperiod": ("between", {"from": f"{year}/00", "to": f"{year}/55"})}
-        filters = {**filters, **year_filter}
-
-        df_list = []
-        pbar = tqdm(self.offices, desc=f"importing module {code}...")
-        for office in pbar:
-            # self.select_office(office)
-            pbar.set_description(f"importing module {code} - {office}...")
-
-            df = self.browse(code=code, fields=fields, filters=filters, company=office, metadata=metadata)
-            if "head.office" not in df.columns:
-                df["head.office"] = office
-            df_list.append(df)
-
-        df = pd.concat(df_list)
-
-        return df


### PR DESCRIPTION
Het lijkt erop dat de administratiecode ontbreekt in openstaande posten bij het gebruiken van de functie query by year. In de PR wordt gechecked of deze kolom er is en zo niet, wordt deze aangemaakt.

Dit is belangrijk, omdat de twinfield package gebouwd is om meerdere administraties aan te kunnen, In alle matches heb je officieel dus deze sleutel nodig.