### PR TITLE
ENH: clean up login and create own exception

### DIFF
--- a/twinfield/api.py
+++ b/twinfield/api.py
@@ -22,13 +22,15 @@ class TwinfieldApi(Base):
         super().__init__()
         self.offices = self.list_offices().index.tolist()
 
-    def list_offices(self) -> pd.DataFrame:
-        offices = Offices(access_token=self.refresh_access_token(), cluster=self.cluster)
+    @staticmethod
+    def list_offices() -> pd.DataFrame:
+        offices = Offices()
         offices_df = offices.list_offices()
 
         return offices_df
 
-    def select_office(self, officecode):
+    @staticmethod
+    def select_office(officecode):
         """
 
         Parameters
@@ -41,7 +43,7 @@ class TwinfieldApi(Base):
             selects the office.
         """
 
-        offices = Offices(access_token=self.refresh_access_token(), cluster=self.cluster)
+        offices = Offices()
         offices.select(officecode=officecode)
 
     @staticmethod

--- a/twinfield/browse.py
+++ b/twinfield/browse.py
@@ -32,7 +32,6 @@ class Browse(Base):
         self.browsecode = code
         self.fields = [x for x in fields if x not in filters.keys()]
         self.filters = filters
-        self.access_token = self.refresh_access_token()
         self.company = company
         self.metadata = metadata
 

--- a/twinfield/core.py
+++ b/twinfield/core.py
@@ -21,7 +21,6 @@ class Base(TwinfieldLogin):
         }
 
         self.namespaces_txt = {k: "{" + v + "}" for k, v in self.namespaces.items()}
-        self.access_token = self.refresh_access_token()
         self.header_req = {"Content-Type": "text/xml", "Accept-Charset": "utf-8"}
 
     def send_request(self, browse) -> requests.Response:

--- a/twinfield/deleted.py
+++ b/twinfield/deleted.py
@@ -21,7 +21,6 @@ class DeletedTransactions(Base):
         """
         super().__init__()
 
-        self.access_token = self.refresh_access_token()
         self.company = company
         self.date_from = date_from
         self.date_to = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")

--- a/twinfield/dimensions.py
+++ b/twinfield/dimensions.py
@@ -19,7 +19,6 @@ class Dimensions(Base):
         """
         super().__init__()
 
-        self.access_token = self.refresh_access_token()
         self.company = company
         self.dimension_type = dim_type
 

--- a/twinfield/exceptions.py
+++ b/twinfield/exceptions.py
@@ -28,3 +28,9 @@ class EnvironmentVariablesError(Exception):
     """Exception when not all env variables are set"""
 
     pass
+
+
+class LoginError(Exception):
+    """Exception when login fails"""
+
+    pass

--- a/twinfield/login.py
+++ b/twinfield/login.py
@@ -21,8 +21,9 @@ class TwinfieldLogin:
         self.check_environment_variables()
 
         self.header = self.create_authorization_header()
-        self.cluster = self.determine_cluster()
         self.access_token = None
+        self.refresh_access_token()
+        self.cluster = self.determine_cluster()
 
     def check_environment_variables(self):
         # Test if environment variables are set for Twinfield login
@@ -48,10 +49,12 @@ class TwinfieldLogin:
 
         json_data = json.loads(response.text)
         access_token = json_data.get("access_token")
-        return access_token
+
+        # store the new access token.
+        self.access_token = access_token
 
     def determine_cluster(self):
-        self.access_token = self.refresh_access_token()
+
         url = f"https://login.twinfield.com/auth/authentication/connect/accesstokenvalidation?token={self.access_token}"
         response = self.do_request(url=url, headers=self.header, req_type="GET")
         json_data = json.loads(response.text)
@@ -105,7 +108,7 @@ class TwinfieldLogin:
                     f"Retry number: {retry}. Error message: {e}"
                 )
                 time.sleep(self.sec_wait)
-                # failed request, retry with new login. Do not do when making login requests
+                # failed request, retry with new access token. Do not do when making login requests
                 if not login_request:
-                    self.cluster = self.determine_cluster()
+                    self.access_token = self.refresh_access_token()
         return output

--- a/twinfield/login.py
+++ b/twinfield/login.py
@@ -7,7 +7,7 @@ import time
 import requests
 from requests.exceptions import SSLError
 
-from twinfield.exceptions import EnvironmentVariablesError
+from twinfield.exceptions import EnvironmentVariablesError, LoginError
 
 
 class TwinfieldLogin:
@@ -22,8 +22,7 @@ class TwinfieldLogin:
 
         self.header = self.create_authorization_header()
         self.cluster = self.determine_cluster()
-
-        self.access_token = self.refresh_access_token()
+        self.access_token = None
 
     def check_environment_variables(self):
         # Test if environment variables are set for Twinfield login
@@ -35,7 +34,7 @@ class TwinfieldLogin:
             )
 
     def create_authorization_header(self):
-        # encode client_id en client_secret to be send as an authorization header in the request.
+        # Encode client_id en client_secret to be sent as an authorization header in the request.
         raw = f"{self.client_id}:{self.client_secret}".encode("ascii")
         base64_credentials = base64.b64encode(raw).decode("ascii")
         header = {"Content-Type": "application/x-www-form-urlencoded ", "Authorization": f"Basic {base64_credentials}"}
@@ -52,13 +51,13 @@ class TwinfieldLogin:
         return access_token
 
     def determine_cluster(self):
-        access_token = self.refresh_access_token()
-        url = f"https://login.twinfield.com/auth/authentication/connect/accesstokenvalidation?token={access_token}"
+        self.access_token = self.refresh_access_token()
+        url = f"https://login.twinfield.com/auth/authentication/connect/accesstokenvalidation?token={self.access_token}"
         response = self.do_request(url=url, headers=self.header, req_type="GET")
         json_data = json.loads(response.text)
         cluster = json_data.get("twf.clusterUrl")
         if not cluster:
-            raise ValueError(f"could not retrieve cluster, message from server: {response.text}")
+            raise LoginError(f"could not retrieve cluster, message from server: {response.text}")
 
         return cluster
 
@@ -99,7 +98,7 @@ class TwinfieldLogin:
                         output = response
                 success = True
 
-            except (ConnectionError, SSLError) as e:
+            except (ConnectionError, SSLError, LoginError) as e:
                 retry += 1
                 logging.exception(
                     f"No response or error, retrying in {self.sec_wait} seconds. "

--- a/twinfield/metadata.py
+++ b/twinfield/metadata.py
@@ -1,3 +1,4 @@
+import logging
 from xml.etree import ElementTree as Et
 
 import pandas as pd
@@ -72,10 +73,9 @@ class Metadata(Base):
         body = root.find("env:Body", self.namespaces)
 
         if body.find("env:Fault", self.namespaces):
-            # TODO: toegevoegd voor debugging.
+            # TODO: added for debugging
             fault = Et.tostring(body)
-            print(fault)
-
+            logging.error(fault)
             raise ServerError()
 
         data = body.find("tw:ProcessXmlStringResponse/tw:ProcessXmlStringResult", self.namespaces)

--- a/twinfield/offices.py
+++ b/twinfield/offices.py
@@ -10,20 +10,11 @@ from twinfield.messages import LIST_OFFICES_XML, SELECT_OFFICE
 
 
 class Offices(Base):
-    def __init__(self, access_token: str, cluster: str):
+    def __init__(self):
         """
         This class is for building the Browse SOAP requests for getting metadata of browse codes
-
-        Parameters
-        ----------
-        access_token: str
-            access_token obtained from TwinfieldApi class.
-        cluster: str
-            cluster obtained from TwinfieldApi class.
         """
         super().__init__()
-        self.access_token = access_token
-        self.cluster = cluster
 
     def select(self, officecode):
         """


### PR DESCRIPTION
closes #100 

Also important to check, I changed the way we set the `access_token`, because right now we requested a new `access_token` in `determine_cluster` method. Then after that we set a new `access_token` in the `__init__` by calling `self.refresh_access_token` again. This could be conflicting I think.

New method sets the class attribute `self.access_token` in the `determine_cluster` function.