### PR TITLE
ENH: catch requests exceptions in general

### DIFF
--- a/twinfield/login.py
+++ b/twinfield/login.py
@@ -103,7 +103,7 @@ class TwinfieldLogin:
                         output = response
                 success = True
 
-            except (ConnectionError, RequestException, LoginError) as e:
+            except (ConnectionError, RequestException, LoginError, json.JSONDecodeError) as e:
                 retry += 1
                 logging.exception(
                     f"No response or error, retrying in {self.sec_wait} seconds. "

--- a/twinfield/login.py
+++ b/twinfield/login.py
@@ -5,7 +5,7 @@ import os
 import time
 
 import requests
-from requests.exceptions import SSLError
+from requests.exceptions import RequestException
 
 from twinfield.exceptions import EnvironmentVariablesError, LoginError
 
@@ -103,7 +103,7 @@ class TwinfieldLogin:
                         output = response
                 success = True
 
-            except (ConnectionError, SSLError, LoginError) as e:
+            except (ConnectionError, RequestException, LoginError) as e:
                 retry += 1
                 logging.exception(
                     f"No response or error, retrying in {self.sec_wait} seconds. "


### PR DESCRIPTION
Right now we catch the builtin python [`ConnectionError`](https://docs.python.org/3/library/exceptions.html#ConnectionError), but this is different from the [`requests.exceptions.ConnectionError`](https://requests.readthedocs.io/en/latest/api/#requests.ConnectionError). Since we in general want to catch any requests error, this PR suggests to catch all the requests errors and try again.

Background: https://stackoverflow.com/questions/16511337/correct-way-to-try-except-using-python-requests-module